### PR TITLE
Sets query string list filters for account_get and container_get #4

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -6,6 +6,7 @@ requires 'Furl';
 requires 'JSON';
 requires 'XML::LibXML';
 requires 'MIME::Types';
+requires 'URI';
 requires 'namespace::clean';
 
 on 'test' => sub {

--- a/t/01_swift-client.t
+++ b/t/01_swift-client.t
@@ -1,24 +1,9 @@
 use Test::More;
-use CIHM::Swift::Client;
 use FindBin;
 
-my $ssscheme = $ENV{'SWIFTSTACK_SCHEME'}      || 'http';
-my $sshost   = $ENV{'SWIFTSTACK_HOST'}        || 'localhost';
-my $ssport   = int( $ENV{'SWIFTSTACK_PORT'} ) || 22222;
-
-if ( !$ENV{'DOCKER_TEST'} ) {
-  eval {
-    require Test::RequiresInternet;
-    Test::RequiresInternet->import( $sshost => $ssport );
-    1;
-  };
-}
-
-my $client = CIHM::Swift::Client->new(
-  server   => "$ssscheme://$sshost:$ssport",
-  user     => $ENV{'SWIFTSTACK_USER'} || 'test',
-  password => $ENV{'SWIFTSTACK_PASSWORD'} || 'test'
-);
+use lib "$FindBin::Bin/lib";
+use boilerplate qw/test_client/;
+my $client = test_client();
 
 my $info = $client->info;
 ok( $info->content->{swift}->{version}, 'can pull swift capabilities' );

--- a/t/02_prefix-delimiter.t
+++ b/t/02_prefix-delimiter.t
@@ -1,0 +1,28 @@
+use Test::More;
+use FindBin;
+
+use lib "$FindBin::Bin/lib";
+use boilerplate qw/test_client/;
+my $client = test_client();
+
+$client->container_put('test');
+$client->object_put( 'test', 'files/meta1.xml',
+  "$FindBin::Bin/files/metadata.xml" );
+$client->object_put( 'test', 'files/meta2.xml',
+  "$FindBin::Bin/files/metadata.xml" );
+$client->object_put( 'test', 'other/meta3.xml',
+  "$FindBin::Bin/files/metadata.xml" );
+
+my $dirs = $client->container_get( 'test', { delimiter => '/' } );
+is( scalar @{ $dirs->content }, 2, 'listing successfully delimited' );
+is( $dirs->content->[1]->{subdir}, 'other/', 'delimited subdir' );
+my $files = $client->container_get( 'test', { prefix => 'other/' } );
+is( $files->content->[0]->{name},
+  'other/meta3.xml', 'subdir prefix successful' );
+
+$client->object_delete( 'test', 'files/meta1.xml' );
+$client->object_delete( 'test', 'files/meta2.xml' );
+$client->object_delete( 'test', 'other/meta3.xml' );
+$client->container_delete('test');
+
+done_testing;

--- a/t/lib/boilerplate.pm
+++ b/t/lib/boilerplate.pm
@@ -1,0 +1,28 @@
+package boilerplate;
+require Exporter;
+our @ISA       = qw/Exporter/;
+our @EXPORT_OK = qw/test_client/;
+
+use CIHM::Swift::Client;
+
+sub test_client {
+  my $ssscheme = $ENV{'SWIFTSTACK_SCHEME'}      || 'http';
+  my $sshost   = $ENV{'SWIFTSTACK_HOST'}        || 'localhost';
+  my $ssport   = int( $ENV{'SWIFTSTACK_PORT'} ) || 22222;
+
+  if ( !$ENV{'DOCKER_TEST'} ) {
+    eval {
+      require Test::RequiresInternet;
+      Test::RequiresInternet->import( $sshost => $ssport );
+      1;
+    };
+  }
+
+  return CIHM::Swift::Client->new(
+    server   => "$ssscheme://$sshost:$ssport",
+    user     => $ENV{'SWIFTSTACK_USER'} || 'test',
+    password => $ENV{'SWIFTSTACK_PASSWORD'} || 'test'
+  );
+}
+
+1;


### PR DESCRIPTION
This allows for `prefix` and `delimiter` list options.